### PR TITLE
Daag 3 (Color Code Nodes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # daunting-aggregate
 
-Creates a directed graph based on an ingested database of backlog items.  Written in Python 3.10.
+Creates a directed graph based on an ingested database of backlog items.  Written in Python 3.10.  Nodes are color-coded by status with the `[COLORS]` scheme.
 
 ## Usage
 
@@ -12,7 +12,15 @@ Creates a directed graph based on an ingested database of backlog items.  Writte
 # Title, Component, Type, Blocked By, Blocks, Status
 DAAG-1,daag,prod,,,Closed
 DAAG-2,wheel,devops,DAAG-1,,Open
-DAAG-3,daag,prod,DAAG-1,,Open
+DAAG-3,daag,prod,DAAG-1,,In Progress
 DAAG-4,daag,prod,DAAG-1,,Open
 DAAG-5,BUG,prod,DAAG-1,,Open
+DAAG-7,BUG,prod,DAAG-1,,Open
+DAAG-8,daag,prod,DAAG-2,,Open
+
+# [COLORS]: <color>,<color>,<color>,<color>,...
+# Colors are applied to the alphabetized status list (e.g., [Closed, In Progress, Open])
+# Default node color is lightgrey
+# For a list of supported X11 colors see: https://graphviz.org/doc/info/colors.html#x11
+[COLORS]: green,green:red,red
 ```

--- a/daag/constants.py
+++ b/daag/constants.py
@@ -12,5 +12,6 @@ from typing import Final
 # Status: current ticket status (e.g., Open, IP, Done)
 Node = namedtuple('Node', ['title', 'component', 'type', 'blocked', 'blocks', 'status'])
 
-OPEN_LIST_DELIM: Final[str] = '['   # Database entry delimiter indicating a list beginning
-CLOSE_LIST_DELIM: Final[str] = ']'  # Database entry delimiter indicating a list ending
+OPEN_LIST_DELIM: Final[str] = '['           # Database entry delimiter indicating a list beginning
+CLOSE_LIST_DELIM: Final[str] = ']'          # Database entry delimiter indicating a list ending
+COLOR_LIST_DELIM: Final[str] = '[COLORS]:'  # Database entry delimiter indicating color scheme

--- a/daag/database.py
+++ b/daag/database.py
@@ -141,7 +141,7 @@ def _parse_node(line: str) -> Node:
     temp_title, temp_comp, temp_type, line = line.split(',', maxsplit=3)
     temp_blocked, line = _parse_list(line)
     temp_blocks, temp_status = _parse_list(line)
-    temp_node = Node(temp_title, temp_comp, temp_type, temp_blocked, temp_blocks, temp_status)
+    node_obj = Node(temp_title, temp_comp, temp_type, temp_blocked, temp_blocks, temp_status)
 
     # DONE
-    return temp_node
+    return node_obj

--- a/daag/database.py
+++ b/daag/database.py
@@ -1,46 +1,101 @@
 """Defines functionality to parse a DAAG database file."""
 # Standard
 from pathlib import Path
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 import sys
 # Third Party
 # Local
-from daag.constants import CLOSE_LIST_DELIM, Node, OPEN_LIST_DELIM
+from daag.constants import CLOSE_LIST_DELIM, COLOR_LIST_DELIM, Node, OPEN_LIST_DELIM
 
 
-def parse_database(dbase: Path) -> List[Node]:
-    """Parse all nodes from a database file.
-
-    Does not validate the validity of dbase but validates the content.
-
-    Args:
-        dbase: Path object of the DAAG database to parse.
-
-    Returns:
-        List of Node namedtuples read from dbase on success.
-    """
+def parse_database(dbase: Path) -> Tuple[List[Node], Dict]:
+    """Parse all nodes and color scheme from a database file."""
     # LOCAL VARIABLES
-    lines = []         # dbase entries
-    node_list = []     # List of Nodes
-    temp_node = None   # Temp Node namedtuple
-    temp_title = ''    # Temp Node.title
-    temp_comp = ''     # Temp Node.comp
-    temp_type = ''     # Temp Node.type
-    temp_blocked = ''  # Temp Node.blocked
-    temp_blocks = ''   # Temp Node.blocks
-    temp_status = ''   # Temp Node.status
+    lines = []       # dbase entries
+    node_list = []   # List of Nodes
+    color_dict = {}  # Dictionary of "status" keys and "color" values
 
     # READ IT
     with open(dbase, 'r', encoding=sys.getdefaultencoding()) as in_file:
         lines = [line for line in in_file.read().split('\n') if line and not line.startswith('#')]
 
+    # NODE LIST
+    node_list = _parse_db_nodes(lines)
+    color_dict = _parse_db_colors(lines, node_list)
+
+    # DONE
+    return tuple((node_list, color_dict))
+
+
+def _parse_db_colors(lines: List[str], node_list: List[Node], default: str = 'lightgrey') -> Dict:
+    """Parses the color scheme and associates the scheme with nodes in a dictionary.
+
+    Dictionary format is <status>:<color>.  Default color is lightgrey.
+
+    Args:
+        lines: List of lines read from the database file.
+        node_list: List of Node namedtuples parsed from the database file.
+        default: Optional; Default color to use.
+            See: https://graphviz.org/doc/info/colors.html#x11
+
+    Raises:
+        RuntimeError: No status found in the node_list.
+
+    Returns:
+        Dictionary of status:color items.
+    """
+    # LOCAL VARIABLES
+    status_list = []  # List of status from the node_list
+    color_list = []   # List of colors found in lines.
+    colors = ''       # Just the colors from the database
+    scheme = {}       # Return value
+
+    # FIND KEYS (STATUS)
+    for node_entry in node_list:
+        if node_entry.status and node_entry.status not in status_list:
+            status_list.append(node_entry.status)
+    # Sort it
+    status_list.sort()
+
+    # FIND VALUES (COLOR SCHEME)
+    for line in lines:
+        if line.startswith(COLOR_LIST_DELIM):
+            colors = line[line.find(COLOR_LIST_DELIM) + len(COLOR_LIST_DELIM):]
+            color_list = colors.strip().split(',')
+            break
+
+    # CREATE DICTIONARY
+    if not status_list:
+        raise RuntimeError('No statuses found in the database')
+    while len(color_list) < len(status_list):
+        color_list.append(default)
+    scheme = dict(zip(status_list, color_list))
+
+    # DONE
+    return scheme
+
+
+def _parse_db_nodes(lines: List[str]) -> List[Node]:
+    """Parse all nodes from a database file.
+
+    Does not validate the validity of dbase but validates the content.
+
+    Args:
+        lines: A list of database entries.
+
+    Returns:
+        List of Node namedtuples read from dbase on success.
+    """
+    # LOCAL VARIABLES
+    node_list = []     # List of Nodes
+    temp_node = None   # Temp Node namedtuple
+
     # PARSE IT
     for line in lines:
-        temp_title, temp_comp, temp_type, line = line.split(',', maxsplit=3)
-        temp_blocked, line = _parse_list(line)
-        temp_blocks, temp_status = _parse_list(line)
-        temp_node = Node(temp_title, temp_comp, temp_type, temp_blocked, temp_blocks, temp_status)
-        node_list.append(temp_node)
+        # Ignore empty lines and the color scheme entry
+        if line and not line.startswith(COLOR_LIST_DELIM):
+            temp_node = _parse_node(line)
+            node_list.append(temp_node)
 
     # DONE
     return node_list
@@ -69,3 +124,24 @@ def _parse_list(line: str) -> Tuple[str, str]:
 
     # DONE
     return tuple((list_entry, remainder))
+
+
+def _parse_node(line: str) -> Node:
+    """Parse a single database entry into a Node."""
+    # LOCAL VARIABLES
+    temp_title = ''    # Temp Node.title
+    temp_comp = ''     # Temp Node.comp
+    temp_type = ''     # Temp Node.type
+    temp_blocked = ''  # Temp Node.blocked
+    temp_blocks = ''   # Temp Node.blocks
+    temp_status = ''   # Temp Node.status
+    node_obj = None    # Return value
+
+    # PARSE IT
+    temp_title, temp_comp, temp_type, line = line.split(',', maxsplit=3)
+    temp_blocked, line = _parse_list(line)
+    temp_blocks, temp_status = _parse_list(line)
+    temp_node = Node(temp_title, temp_comp, temp_type, temp_blocked, temp_blocks, temp_status)
+
+    # DONE
+    return temp_node

--- a/daag/main.py
+++ b/daag/main.py
@@ -15,15 +15,17 @@ def main() -> int:
         0 on success, 1 on error/Exception.
     """
     # LOCAL VARIABLES
-    retval = 0        # 0 for success, 1 on error
-    dbase = None      # Path object for the input database
-    node_list = []    # List of Nodes
-    graph_obj = None  # graphviz.dot.Digraph object
+    retval = 0         # 0 for success, 1 on error
+    dbase = None       # Path object for the input database
+    node_list = []     # List of Nodes
+    color_scheme = {}  # status:color
+    graph_obj = None   # graphviz.dot.Digraph object
 
     try:
         dbase = parse_args()
-        node_list = parse_database(dbase)
-        graph_obj = create_graph(name=dbase.stem.split('.')[0], node_list=node_list)
+        node_list, color_scheme = parse_database(dbase)
+        graph_obj = create_graph(name=dbase.stem.split('.')[0], node_list=node_list,
+                                 color_scheme=color_scheme)
         graph_obj.view()
     # pylint: disable=broad-except
     except Exception as err:


### PR DESCRIPTION
Added new (janky) functionality to the database file.
Set a color scheme using `[COLORS]:`

Don't like the database file format?  Neither do it.  It works as-is.  However, I added a backlog ticket to transition the format to a *real* format (see: #8 )